### PR TITLE
add webpack 2

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
-  "lerna": "2.0.0-beta.26",
+  "lerna": "2.0.0-beta.28",
   "version": "3.4.3"
 }

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "js-cookie": "^2.1.0",
     "js-yaml": "^3.5.5",
     "key-mirror": "^1.0.1",
-    "lerna": "2.0.0-beta.26",
+    "lerna": "2.0.0-beta.28",
     "lodash": "^4.0.0",
     "meow": "^3.7.0",
     "mockery": "^1.7.0",
@@ -90,7 +90,7 @@
     "run-sequence": "^1.1.5",
     "semver": "^5.1.0",
     "sinon": "^1.17.3",
-    "webpack": "^1.12.14"
+    "webpack": "^2.1.0-beta.22"
   },
   "dependencies": {
     "babel-plugin-transform-runtime": "^6.8.0",

--- a/packages/boiler-addon-assemble-isomorphic-memory/package.json
+++ b/packages/boiler-addon-assemble-isomorphic-memory/package.json
@@ -37,7 +37,7 @@
     "snyk": "^1.18.0"
   },
   "peerDependencies": {
-    "webpack": "1.x"
+    "webpack": "2.1.0-beta.22"
   },
   "scripts": {
     "test": "snyk test",

--- a/packages/boiler-addon-webpack-babel/package.json
+++ b/packages/boiler-addon-webpack-babel/package.json
@@ -45,7 +45,7 @@
     "snyk": "^1.18.0"
   },
   "peerDependencies": {
-    "webpack": "1.x"
+    "webpack": "2.1.0-beta.22"
   },
   "scripts": {
     "test": "snyk test",

--- a/packages/boiler-addon-webpack-isomorphic/package.json
+++ b/packages/boiler-addon-webpack-isomorphic/package.json
@@ -34,7 +34,7 @@
     "snyk": "^1.18.0"
   },
   "peerDependencies": {
-    "webpack": "1.x"
+    "webpack": "2.1.0-beta.22"
   },
   "scripts": {
     "test": "snyk test",

--- a/packages/boiler-addon-webpack-karma/package.json
+++ b/packages/boiler-addon-webpack-karma/package.json
@@ -36,7 +36,7 @@
     "snyk": "^1.18.0"
   },
   "peerDependencies": {
-    "webpack": "1.x"
+    "webpack": "2.1.0-beta.22"
   },
   "scripts": {
     "test": "snyk test",

--- a/packages/boiler-addon-webpack-loaders-base/package.json
+++ b/packages/boiler-addon-webpack-loaders-base/package.json
@@ -39,7 +39,7 @@
     "snyk": "^1.18.0"
   },
   "peerDependencies": {
-    "webpack": "1.x"
+    "webpack": "2.1.0-beta.22"
   },
   "scripts": {
     "test": "snyk test",

--- a/packages/boiler-addon-webpack-loaders-optimize/package.json
+++ b/packages/boiler-addon-webpack-loaders-optimize/package.json
@@ -34,7 +34,7 @@
     "snyk": "^1.18.0"
   },
   "peerDependencies": {
-    "webpack": "1.x"
+    "webpack": "2.1.0-beta.22"
   },
   "scripts": {
     "test": "snyk test",

--- a/packages/boiler-addon-webpack-styles/package.json
+++ b/packages/boiler-addon-webpack-styles/package.json
@@ -30,7 +30,7 @@
     "babel-plugin-transform-runtime": "^6.8.0",
     "boiler-utils": "^3.4.3",
     "css-loader": "^0.23.0",
-    "extract-text-webpack-plugin": "^1.0.1",
+    "extract-text-webpack-plugin": "2.0.0-beta.4",
     "lodash": "^4.0.0",
     "node-sass": "3.8.0",
     "postcss": "^5.0.0",
@@ -41,7 +41,7 @@
     "style-loader": "^0.13.0"
   },
   "peerDependencies": {
-    "webpack": "1.x"
+    "webpack": "2.1.0-beta.22"
   },
   "scripts": {
     "test": "snyk test",

--- a/packages/boiler-addon-webpack-styles/src/loaders.js
+++ b/packages/boiler-addon-webpack-styles/src/loaders.js
@@ -40,11 +40,14 @@ export default function(config, data) {
         `sass-loader?${sassParams.join('&')}`
       ].join('!');
     } else {
-      sassLoader = ExtractTextPlugin.extract('style-loader', [
-        `css-loader?importLoaders=2${sourceMap}`,
-        'postcss-loader',
-        `sass-loader?${sassParams.join('&')}`
-      ].join('!'));
+      sassLoader = ExtractTextPlugin.extract({
+        fallbackLoader: 'style-loader',
+        loader: [
+          `css-loader?importLoaders=2${sourceMap}`,
+          'postcss-loader',
+          `sass-loader?${sassParams.join('&')}`
+        ].join('!')
+      });
     }
 
     cssLoader = [
@@ -53,16 +56,22 @@ export default function(config, data) {
       'postcss-loader'
     ].join('!');
   } else {
-    cssLoader = ExtractTextPlugin.extract('style-loader', [
-      `css-loader?importLoaders=1&modules&localIdentName=[hash:base64:5]${sourceMap}`,
-      'postcss-loader'
-    ].join('!'));
+    cssLoader = ExtractTextPlugin.extract({
+      fallbackLoader: 'style-loader',
+      loader: [
+        `css-loader?importLoaders=1&modules&localIdentName=[hash:base64:5]${sourceMap}`,
+        'postcss-loader'
+      ].join('!')
+    });
 
-    sassLoader = ExtractTextPlugin.extract('style-loader', [
-      `css-loader?importLoaders=2${sourceMap}`,
-      'postcss-loader',
-      `sass-loader?${sassParams.join('&')}`
-    ].join('!'));
+    sassLoader = ExtractTextPlugin.extract({
+      fallbackLoader: 'style-loader',
+      loader: [
+        `css-loader?importLoaders=2${sourceMap}`,
+        'postcss-loader',
+        `sass-loader?${sassParams.join('&')}`
+      ].join('!')
+    });
   }
 
   loaders.push(...[

--- a/packages/boiler-addon-webpack-styles/src/plugins.js
+++ b/packages/boiler-addon-webpack-styles/src/plugins.js
@@ -18,7 +18,8 @@ export default function(config, data) {
 
   if (extractCss || extractScss) {
     plugins.push(
-      new ExtractTextPlugin(cssBundleName, {
+      new ExtractTextPlugin({
+        filename: cssBundleName,
         allChunks: true
       })
     );

--- a/packages/boiler-config-webpack/package.json
+++ b/packages/boiler-config-webpack/package.json
@@ -40,7 +40,7 @@
     "snyk": "^1.18.0"
   },
   "peerDependencies": {
-    "webpack": "1.x"
+    "webpack": "2.1.0-beta.22"
   },
   "scripts": {
     "test": "snyk test",

--- a/packages/boiler-task-webpack/package.json
+++ b/packages/boiler-task-webpack/package.json
@@ -34,12 +34,12 @@
     "fs-extra": "^0.30.0",
     "globby": "^4.0.0",
     "lodash": "^4.0.0",
+    "snyk": "^1.18.0",
     "webpack-dev-middleware": "^1.5.1",
-    "webpack-hot-middleware": "2.7.1",
-    "snyk": "^1.18.0"
+    "webpack-hot-middleware": "^2.12.2"
   },
   "peerDependencies": {
-    "webpack": "1.x"
+    "webpack": "2.1.0-beta.22"
   },
   "scripts": {
     "test": "snyk test",

--- a/packages/boiler-utils/src/install-peer-dep.js
+++ b/packages/boiler-utils/src/install-peer-dep.js
@@ -25,7 +25,19 @@ export default function(rootDir, addon) {
     const version = peerDependencies[name];
     const exists = tryExists(name, {resolve: true, omitReq: true});
 
-    return exists ? list : [...list, `${name}@${version}`];
+    if (exists) {
+      const re = new RegExp(`^(.*/node_modules/${name}/).*$`);
+      const modulePath = exists.replace(re, '$1package.json');
+      const {version: installedVersion} = require(modulePath);
+
+      if (installedVersion !== version) {
+        list.push(`${name}@${version}`);
+      }
+    } else {
+      list.push(`${name}@${version}`);
+    }
+
+    return list;
   }, []).join(' ');
   const installed = [];
 


### PR DESCRIPTION
#### Description
Added webpack 2 and related upgrades
- plugin syntax only takes an `Object` as a single argument
- upgrade `webpack-hot-middleware`
- upgrade `extract-text-plugin`

Unfortunately, this most likely requires your re-install all the things. This should also coincide with a major version bump to 4.0.0

#### To Test
- `rm -rf {node_modules/packages/*/node_modules}`
- `npm i && npm run lerna:bootstrap` if you dare
- `gulp watch` test components in `lib` to see if they hot reload
- test SCSS to see that it livereloads
- test `src/js/index.js` to see that it livereloads
- `gulp build && gulp browser-sync` see that isomorphic stuff works and script/link tags have subresource integrity data/attributes
- `gulp test:integration` this compiles using webpack so important to see if it still works. save a test file and see that the watch runs

#### Notes
Would be interesting to compare bundle sizes between Webpack 1 and Webpack 2, plus explore tree shaking and code splitting via `System.import` sytax
- https://github.com/webpack/webpack/issues/1981
- https://github.com/webpack/webpack/issues/2873
- https://gist.github.com/mxstbr/85b1c37276162b6ceb33
- https://gist.github.com/sokra/27b24881210b56bbaff7