### PR TITLE
upgrade to 2.1.0-beta.25

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "run-sequence": "^1.1.5",
     "semver": "^5.1.0",
     "sinon": "^1.17.3",
-    "webpack": "2.1.0-beta.22"
+    "webpack": "2.1.0-beta.25"
   },
   "dependencies": {
     "babel-plugin-transform-runtime": "^6.8.0",

--- a/packages/boiler-addon-assemble-isomorphic-memory/package.json
+++ b/packages/boiler-addon-assemble-isomorphic-memory/package.json
@@ -37,7 +37,7 @@
     "through2": "^2.0.0"
   },
   "peerDependencies": {
-    "webpack": "2.1.0-beta.22"
+    "webpack": "2.1.0-beta.25"
   },
   "scripts": {
     "test": "snyk test",

--- a/packages/boiler-addon-webpack-babel/package.json
+++ b/packages/boiler-addon-webpack-babel/package.json
@@ -45,7 +45,7 @@
     "snyk": "^1.18.0"
   },
   "peerDependencies": {
-    "webpack": "2.1.0-beta.22"
+    "webpack": "2.1.0-beta.25"
   },
   "scripts": {
     "test": "snyk test",

--- a/packages/boiler-addon-webpack-isomorphic/package.json
+++ b/packages/boiler-addon-webpack-isomorphic/package.json
@@ -34,7 +34,7 @@
     "snyk": "^1.18.0"
   },
   "peerDependencies": {
-    "webpack": "2.1.0-beta.22"
+    "webpack": "2.1.0-beta.25"
   },
   "scripts": {
     "test": "snyk test",

--- a/packages/boiler-addon-webpack-karma/package.json
+++ b/packages/boiler-addon-webpack-karma/package.json
@@ -36,7 +36,7 @@
     "uglify-loader": "^1.3.0"
   },
   "peerDependencies": {
-    "webpack": "2.1.0-beta.22"
+    "webpack": "2.1.0-beta.25"
   },
   "scripts": {
     "test": "snyk test",

--- a/packages/boiler-addon-webpack-loaders-base/package.json
+++ b/packages/boiler-addon-webpack-loaders-base/package.json
@@ -39,7 +39,7 @@
     "style-loader": "^0.13.0"
   },
   "peerDependencies": {
-    "webpack": "2.1.0-beta.22"
+    "webpack": "2.1.0-beta.25"
   },
   "scripts": {
     "test": "snyk test",

--- a/packages/boiler-addon-webpack-loaders-optimize/package.json
+++ b/packages/boiler-addon-webpack-loaders-optimize/package.json
@@ -34,7 +34,7 @@
     "url-loader": "^0.5.6"
   },
   "peerDependencies": {
-    "webpack": "2.1.0-beta.22"
+    "webpack": "2.1.0-beta.25"
   },
   "scripts": {
     "test": "snyk test",

--- a/packages/boiler-addon-webpack-styles/package.json
+++ b/packages/boiler-addon-webpack-styles/package.json
@@ -41,7 +41,7 @@
     "style-loader": "^0.13.0"
   },
   "peerDependencies": {
-    "webpack": "2.1.0-beta.22"
+    "webpack": "2.1.0-beta.25"
   },
   "scripts": {
     "test": "snyk test",

--- a/packages/boiler-config-webpack/package.json
+++ b/packages/boiler-config-webpack/package.json
@@ -40,7 +40,7 @@
     "url-loader": "^0.5.6"
   },
   "peerDependencies": {
-    "webpack": "2.1.0-beta.22"
+    "webpack": "2.1.0-beta.25"
   },
   "scripts": {
     "test": "snyk test",

--- a/packages/boiler-config-webpack/src/index.js
+++ b/packages/boiler-config-webpack/src/index.js
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import _ from 'lodash';
 import makeConfig from './make-webpack-config';
+import transformWebpack2Props from './utils/transform-webpack-2-properties';
 
 export default function(config) {
   const {
@@ -47,14 +48,11 @@ export default function(config) {
   const defaultConfig = {
     context,
     resolveLoader: {
-      //fallback for Webpack 1
-      modulesDirectories: loaderRoot,
       modules: loaderRoot
     },
     resolve: {
       alias,
       extensions: [
-        '',
         '.js',
         '.json',
         '.jsx',
@@ -64,8 +62,6 @@ export default function(config) {
         '.yaml',
         '.yml'
       ],
-      //fallback for Webpack 1
-      modulesDirectories: moduleRoot,
       modules: moduleRoot
     },
     node,
@@ -76,5 +72,7 @@ export default function(config) {
     dirs: moduleDirs
   });
 
-  return configMethods[ENV]();
+  return transformWebpack2Props(
+    configMethods[ENV]()
+  );
 }

--- a/packages/boiler-config-webpack/src/make-webpack-config.js
+++ b/packages/boiler-config-webpack/src/make-webpack-config.js
@@ -166,7 +166,6 @@ export default function(config, defaultConfig, opts = {}) {
 
   assign(defaultConfig, {
     cache: isDev,
-    debug: isDev,
     externals,
     output: {
       path: addbase(buildDir),

--- a/packages/boiler-config-webpack/src/utils/transform-webpack-2-properties.js
+++ b/packages/boiler-config-webpack/src/utils/transform-webpack-2-properties.js
@@ -1,0 +1,99 @@
+import {LoaderOptionsPlugin} from 'webpack';
+
+const webpackConfigWhitelist = [
+  'amd',
+  'bail',
+  'cache',
+  'context',
+  'dependencies',
+  'devServer',
+  'devtool',
+  'entry',
+  'externals',
+  'loader',
+  'module',
+  'name',
+  'node',
+  'output',
+  'plugins',
+  'profile',
+  'recordsInputPath',
+  'recordsOutputPath',
+  'recordsPath',
+  'resolve',
+  'resolveLoader',
+  'stats',
+  'target',
+  'watch',
+  'watchOptions'
+];
+const skip = ['methods', 'debug'];
+
+/**
+ * Reduce over the loaders to transform `module.{preLoaders,loaders,postLoaders}` syntax
+ * @param {Object} moduleConfig webpack config for `.module` property
+ * @return {Object} match `module.rules` syntax https://github.com/TheLarkInn/angular-cli/blob/63801b48fa4ec0b48005ceed74bd0c03854b4c8e/packages/angular-cli/models/webpack-build-common.ts#L44
+ */
+function loaderReducer(moduleConfig) {
+  return Object.keys(moduleConfig).reduce((acc, name) => {
+    const loaderList = moduleConfig[name];
+    let enforce;
+
+    switch (name) {
+      case 'preLoaders':
+        enforce = 'pre';
+        break;
+      case 'postLoaders':
+        enforce = 'post';
+        break;
+    }
+
+    const rules = loaderList.map(loader => {
+      if (enforce) {
+        Object.assign(loader, {enforce});
+      }
+
+      return loader;
+    });
+
+    acc.rules = acc.rules || [];
+    acc.rules.push(...rules);
+
+    return acc;
+  }, {});
+}
+
+/**
+ * Utility to transform properties not accepted since `v2.1.0-beta.23`
+ * @param {Object} webpackConfig config passed to the `webpack` compiler
+ * @return {Object}
+ */
+export default function(webpackConfig) {
+  const keys = Object.keys(webpackConfig);
+  const len = keys.length - 1;
+  const loaderOptions = [];
+
+  return keys.reduce((acc, key, i) => {
+    if (skip.includes(key)) return acc;
+
+    const val = webpackConfig[key];
+
+    if (!webpackConfigWhitelist.includes(key)) {
+      loaderOptions.push(
+        new LoaderOptionsPlugin({
+          [key]: val
+        })
+      );
+    } else if (key === 'module') {
+      acc[key] = loaderReducer(val);
+    } else {
+      acc[key] = val;
+    }
+
+    if (i === len) {
+      acc.plugins.push(...loaderOptions);
+    }
+
+    return acc;
+  }, {});
+}


### PR DESCRIPTION
#### Description
annoying, `module.{preLoaders,loaders,postLoaders}` is now `module.rules`

https://github.com/angular/angular-cli/pull/2237/files

#### To Test
You will unfortunately have to remove most if not all of your node modules to ensure that there is no mismatch of webpack dependencies. After that:
- `gulp watch` introduce linting errors, see the cool linting overlay in the browser. make sure react components hot reload
- `gulp build` inspect that isomorphic still works
- `gulp test:integration --coverage`
- `gulp karma --coverage`