### PR TITLE
add md5 hash plugin for webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "eslint-config-airbnb": "^12.0.0",
     "eslint-config-airbnb-base": "^8.0.0",
     "eslint-config-babel": "^2.0.1",
-    "eslint-friendly-formatter": "^1.2.2",
+    "eslint-friendly-formatter": "2.0.6",
     "eslint-plugin-babel": "^3.3.0",
     "eslint-plugin-import": "^2.0.0",
     "eslint-plugin-jsx-a11y": "^2.2.3",

--- a/packages/boiler-addon-assemble-nunjucks/src/tags/get-asset.js
+++ b/packages/boiler-addon-assemble-nunjucks/src/tags/get-asset.js
@@ -166,6 +166,16 @@ export default class GetAsset {
         break;
     }
 
+    if (this.integrity) {
+      // HACK: previous runs to the get_asset tag were mutating the `this.integrity` state so if `integrity=true` was taken off
+      // of one tag, if a previous tag with "integrity" had run, then the following tag would still persist the integrity state
+      this.integrity = null;
+    }
+
+    if (this.cors) {
+      this.cors = null;
+    }
+
     return new nunjucks.runtime.SafeString(tag || '');
   }
 }

--- a/packages/boiler-config-webpack/package.json
+++ b/packages/boiler-config-webpack/package.json
@@ -37,7 +37,8 @@
     "snyk": "^1.18.0",
     "source-map-support": "^0.4.0",
     "sri-stats-webpack-plugin": "^0.7.2",
-    "url-loader": "^0.5.6"
+    "url-loader": "^0.5.6",
+    "webpack-md5-hash": "0.0.5"
   },
   "peerDependencies": {
     "webpack": "2.1.0-beta.25"

--- a/packages/boiler-config-webpack/package.json
+++ b/packages/boiler-config-webpack/package.json
@@ -30,7 +30,7 @@
     "boiler-addon-isomorphic-tools": "^5.1.4",
     "boiler-config-eslint": "^5.1.5",
     "boiler-utils": "^5.1.4",
-    "eslint-friendly-formatter": "^1.2.2",
+    "eslint-friendly-formatter": "2.0.6",
     "globby": "^4.0.0",
     "gulp-util": "^3.0.7",
     "lodash": "^4.0.0",

--- a/packages/boiler-config-webpack/src/make-webpack-config.js
+++ b/packages/boiler-config-webpack/src/make-webpack-config.js
@@ -7,6 +7,7 @@ import {join} from 'path';
 import webpack from 'webpack';
 import formatter from 'eslint-friendly-formatter';
 import boilerUtils from 'boiler-utils';
+import WebpackMd5Hash from 'webpack-md5-hash';
 import getLoaderPluginConfig from './get-loader-plugin-config';
 import createMultipleEntries from './make-multiple-entries';
 import applyAddons from './utils/apply-addons';
@@ -207,6 +208,10 @@ export default function(config, defaultConfig, opts = {}) {
         })
       ]);
     }
+
+    prodConfig.plugins.push(
+      new WebpackMd5Hash()
+    );
 
     return prodConfig;
   };

--- a/packages/boiler-task-eslint/package.json
+++ b/packages/boiler-task-eslint/package.json
@@ -30,7 +30,7 @@
     "boiler-config-eslint": "^5.1.5",
     "boiler-utils": "^5.1.4",
     "eslint": "^3.4.0",
-    "eslint-friendly-formatter": "^1.1.0",
+    "eslint-friendly-formatter": "2.0.6",
     "gulp-eslint": "^3.0.1",
     "gulp-if": "^2.0.1"
   },

--- a/src/templates/layouts/default.html
+++ b/src/templates/layouts/default.html
@@ -15,6 +15,8 @@
     </div>
     {% debug key='page_data' %}
     {% debug key='page_json' %}
+    {% debug key='assets.javascript' %}
+    {% debug key='assets.styles' %}
 
     <script>window.userName = "{{userName}}"</script>
     <script src="//ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>


### PR DESCRIPTION
#### Description
Hashes were differing between bundles for JS and CSS even if file contents had changed. Therefore, filenames were overlapping and cached files were sometimes being served breaking subresource integrity. Only solution to this seems to use the webpack-md5-hash plugin. Multiple issues are on the Webpack repo and the maintainers responded confirming this was indeed still a bug that needs to be addressed in `webpack@2`. Additionally, I hacked around state mutation in the `get_assets` template tag allowing subresource integrity to be disabled on one asset type and style enabled on a different asset type.

https://github.com/webpack/webpack/issues/1155#issuecomment-254679314

#### To Test
- `npm run lerna:bootstrap`
- `gulp build` inspect the hashed file paths
- run `gulp build` again and inspect that nothing changed
- change something in JS or CSS and run `gulp build`. ensure that the coinciding bundle has a changed hash
- to test subresource integrity remove the `integrity=true` attribute from one of the `get_assets` tags
- `gulp build` and inspect that the subresource integrity attributes are removed from those tag types but still enabled for the others

#### Note
Two Travis builds were run for this PR and 

![screen shot 2016-10-19 at 11 40 07 am](https://cloud.githubusercontent.com/assets/4656726/19525983/d7cef0e0-95f0-11e6-9a7f-6363bfe55ebf.png)
