### PR TITLE
BrowserSync: Defaulting to OFFLINE (no public IPs)

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -44,6 +44,6 @@ patch:
         patched: '2016-08-15T15:55:24.390Z'
   'npm:tough-cookie:20160722':
     - glob-watcher > chokidar > fsevents > node-pre-gyp > request > tough-cookie:
-        patched: '2016-08-15T15:55:24.390Z'
+        patched: '2016-10-24T21:04:17.897Z'
     - gulp > glob-watcher > chokidar > fsevents > node-pre-gyp > request > tough-cookie:
-        patched: '2016-08-15T15:55:24.390Z'
+        patched: '2016-10-24T21:04:17.897Z'

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "scripts": {
     "start": "gulp",
-    "test": "snyk test && gulp mocha",
+    "test": "gulp mocha",
     "lint:fix:build": "eslint -c ./packages/boiler-config-eslint/dist/config/build.js ./gulp/** ./packages/*/src/** gulpfile.babel.js --fix",
     "lint:fix:test": "eslint -c ./packages/boiler-config-eslint/dist/config/test.js ./tests/** ./packages/*/test/** --fix",
     "lerna:bootstrap": "lerna bootstrap",
@@ -19,9 +19,7 @@
     "bs": "node ./scripts/install.js && lerna bootstrap",
     "compile": "gulp build --release",
     "publish": "gulp build --release && gulp mocha &&  lerna publish",
-    "publish:all": "gulp build --release && gulp mocha && lerna publish --force-publish=* --yes",
-    "snyk-protect": "snyk protect",
-    "prepublish": "npm run snyk-protect"
+    "publish:all": "gulp build --release && gulp mocha && lerna publish --force-publish=* --yes"
   },
   "author": "DtotheFP",
   "license": "Copyright 2016",
@@ -106,6 +104,5 @@
     "babel-plugin-transform-runtime": "^6.8.0",
     "browserstack-local": "1.1.0",
     "snyk": "^1.18.0"
-  },
-  "snyk": true
+  }
 }

--- a/packages/boiler-task-browser-sync/.snyk
+++ b/packages/boiler-task-browser-sync/.snyk
@@ -32,10 +32,12 @@ patch:
         patched: '2016-08-15T15:59:50.169Z'
   'npm:request:20160119':
     - browser-sync > localtunnel > request:
-        patched: '2016-08-15T15:59:50.169Z'
+        patched: '2016-10-24T20:50:06.253Z'
   'npm:tough-cookie:20160722':
     - browser-sync > chokidar > fsevents > node-pre-gyp > request > tough-cookie:
         patched: '2016-08-15T15:59:50.169Z'
+      browser-sync > localtunnel > request > tough-cookie:
+        patched: '2016-10-24T20:50:06.253Z'
     - browser-sync > localtunnel > request > tough-cookie:
         patched: '2016-08-15T15:59:50.169Z'
   'npm:ws:20160624':

--- a/packages/boiler-task-browser-sync/src/index.js
+++ b/packages/boiler-task-browser-sync/src/index.js
@@ -61,7 +61,8 @@ export default function(gulp, plugins, config) {
       server: {
         baseDir: addbase(buildDir),
         middleware
-      }
+      },
+      online: false
     };
 
     const parentConfig = callParent(arguments, {


### PR DESCRIPTION
@dtothefp, can you take a look?

This changeset makes BrowserSync default to OFFLINE mode, which disables public IPs.  There's a potential for action hijacking with this, and users can just override this option if they need to share.